### PR TITLE
ENH: allow to initialize adapt_radius before entering warp function

### DIFF
--- a/src/plastimatch/register/rbf_gauss.cxx
+++ b/src/plastimatch/register/rbf_gauss.cxx
@@ -543,14 +543,18 @@ rbf_gauss_warp (Landmark_warp *lw)
     Volume::Pointer moving;
     Volume *vf_out, *warped_out;
 
-    lw->adapt_radius = (float *)malloc(lw->m_fixed_landmarks.get_count()*sizeof(float));
+    bool adapt_radius_initialized = (lw->adapt_radius[0] != 0);
+
+    if (!adapt_radius_initialized){
+        lw->adapt_radius = (float *)malloc(lw->m_fixed_landmarks.get_count()*sizeof(float));
+    }
     lw->cluster_id = (int *)malloc(lw->m_fixed_landmarks.get_count()*sizeof(int));
 
     if (lw->num_clusters > 0) {
 	rbf_cluster_kmeans_plusplus( lw );
 	rbf_cluster_find_adapt_radius( lw );
     }
-    else {
+    else if (!adapt_radius_initialized){
 	for (size_t i = 0; i < lw->m_fixed_landmarks.get_count(); i++) 
 	    lw->adapt_radius[i]=lw->rbf_radius;
     }

--- a/src/plastimatch/register/rbf_wendland.cxx
+++ b/src/plastimatch/register/rbf_wendland.cxx
@@ -206,7 +206,11 @@ rbf_wendland_warp (Landmark_warp *lw)
 
     //printf ("Wendland Radial basis functions requested, radius %.2f\n", lw->rbf_radius);
 
-    lw->adapt_radius = (float *)malloc(lw->m_fixed_landmarks.get_count() * sizeof(float));
+    bool adapt_radius_initialized = (lw->adapt_radius[0] != 0);
+
+    if (!adapt_radius_initialized){
+        lw->adapt_radius = (float *)malloc(lw->m_fixed_landmarks.get_count()*sizeof(float));
+    }
     lw->cluster_id = (int *)malloc(lw->m_fixed_landmarks.get_count() * sizeof(int));
 
     if (lw->num_clusters > 0) {
@@ -215,7 +219,7 @@ rbf_wendland_warp (Landmark_warp *lw)
          // using cluster_id, fill in lw->adapt_radius
         rbf_cluster_find_adapt_radius( lw );
     }
-    else {
+    else if (!adapt_radius_initialized){
         // use the specified radius
         for (size_t i = 0; i < lw->m_fixed_landmarks.get_count(); i++) {
             lw->adapt_radius[i]=lw->rbf_radius;


### PR DESCRIPTION
Hi, in the context of [this](https://discourse.slicer.org/t/plastimatch-landwarp-with-variable-rbf-radius/20226) discussion, these changes allow to specify the adapt_radius before entering the warp functions.

I use this functionality in landwarp module from SlicerRt, see proposed changes here: SlicerRt/SlicerRT#200

I'm not sure wether this PR should go here or in plastimatch source.

Thanks!